### PR TITLE
Extra tags with more metadata 

### DIFF
--- a/ogc/provision.py
+++ b/ogc/provision.py
@@ -254,8 +254,8 @@ class AWSProvisioner(BaseProvisioner):
             now = datetime.datetime.utcnow().strftime("created-%Y-%m-%d")
             layout["tags"].append(now)
             layout["tags"].append(f"user-{user.slug}")
-            tags["Created"] = now
-            tags["UserTag"] = f"user-{user.slug}"
+            tags["created"] = now
+            tags["user_tag"] = f"user-{user.slug}"
 
         node = self._create_node(**opts)
         self.provisioner.ex_create_tags(self.node(instance_id=node.instance_id), tags)

--- a/ogc/provision.py
+++ b/ogc/provision.py
@@ -256,6 +256,11 @@ class AWSProvisioner(BaseProvisioner):
             layout["tags"].append(f"user-{user.slug}")
             tags["created"] = now
             tags["user_tag"] = f"user-{user.slug}"
+            # Store some extra metadata similar to what other projects use
+            epoch = datetime.datetime.now().timestamp()
+            tags["created_date"] = epoch
+            tags["environment"] = "ogc"
+            tags["repo"] = "ogc"
 
         node = self._create_node(**opts)
         self.provisioner.ex_create_tags(self.node(instance_id=node.instance_id), tags)


### PR DESCRIPTION
## What does this PR do?

Standardise the below tags/labels in the Cloud resources for AWS/GCP:

- `environment` => static value
- `repo`.              => static value
- `created_date` => dynamic value

## Why is it important?

Help with tearing down any of the ephemeral resources which were not successfully destroyed as part of the system tests.

## Implementation details

* Those tag/labels are lowercase based to be [GCP](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements)/[AWS](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions) compliance
* `environment=ogc` will allow to filter all those cloud resources which were created by this tool
* While `created_date` will help to filter those which were older than X days or X hours, since it's Unix epoch time based.

## Issues

Similar to https://github.com/elastic/elastic-package/pull/792
